### PR TITLE
sf Polygon handling improvement

### DIFF
--- a/R/calcLineLength.R
+++ b/R/calcLineLength.R
@@ -15,21 +15,21 @@
 #' from past surveys are likely your best option here.  Used to calculate the
 #' expected density of pronghorn in the survey area.
 #' @param p Scalar, expected probability of detecting pronghorn in the herd
-#' unit.  Defaults to 0.58, the average p from past surveys in Wyoming.
+#' unit.  Defaults to 0.58, the average p from surveys conducted before 2022.
 #' @param w Scalar, width (m) of the survey strip.  Defaults to 200 m, the
 #' standard width using the Wyoming survey protocol.
 #' @param targetGroups Scalar, number of groups to detect.  Defaults to 300
 #' pronghorn groups, which is a bit subjective, but should provide plenty of
 #' detections to fit a robust detection model.
 #' @param avgGroupSize Scalar, expected average number of pronghorn in each
-#' group detected.  Defaults to 2.3, the average group size from past surveys
-#' in Wyoming.
+#' group detected.  Defaults to 2.3, the average group size from surveys
+#' conducted before 2022.
 #' @author Jason Carlisle, based on some clever back-of-the-napkin math by Trent
 #' McDonald and Greg Hiatt at a WGFD training on pronghorn LT surveys in Laramie
 #' in April 2022.
 #'
 #' @return Scalar, the total length (km) of transects to survey.
-#' @importFrom sf st_area
+#' @importFrom sf st_area st_union
 #' @export
 #'
 #'
@@ -51,8 +51,18 @@ calcLineLength <- function(occupiedPolygon,
                            targetGroups = 300,
                            avgGroupSize = 2.3) {
 
-  # Union for multiple features
-  occupiedPolygon <- sf::st_union(occupiedPolygon)
+
+  # Special handling for polygons with multiple features
+  if (nrow(occupiedPolygon) > 1) {
+
+    # Issue warning
+    warning("Your input polygon has >1 feature and has been dissolved into 1 feature.")
+
+    # Union for multiple features
+    occupiedPolygon <- sf::st_union(occupiedPolygon)
+
+  }
+
 
   # Calculate area
   area <- sf::st_area(occupiedPolygon)

--- a/R/calcLineLength.R
+++ b/R/calcLineLength.R
@@ -51,6 +51,9 @@ calcLineLength <- function(occupiedPolygon,
                            targetGroups = 300,
                            avgGroupSize = 2.3) {
 
+  # Union for multiple features
+  occupiedPolygon <- sf::st_union(occupiedPolygon)
+
   # Calculate area
   area <- sf::st_area(occupiedPolygon)
 

--- a/R/makeLines.R
+++ b/R/makeLines.R
@@ -101,6 +101,11 @@ makeLines <- function(sPoly,
     # transform xPoly to be in same crs as sPoly
     xPoly <- sf::st_transform(xPoly, sf::st_crs(sPoly))
 
+    # convert xPoly to POLYGON if MULTIPOLYGON
+    if ("sfc_MULTIPOLYGON" %in% class(xPoly$geometry)) {
+      xPoly <- sf::st_cast(xPoly, "POLYGON")
+    }
+
     # then append cutouts for spatstat.geom::owin() to the owinList
     for (row in 1:nrow(xPoly)) {
       xCoords <- sf::st_coordinates(xPoly[row,])

--- a/R/makeLines.R
+++ b/R/makeLines.R
@@ -103,7 +103,7 @@ makeLines <- function(sPoly,
 
     # convert xPoly to POLYGON if MULTIPOLYGON
     if ("sfc_MULTIPOLYGON" %in% class(xPoly$geometry)) {
-      xPoly <- sf::st_cast(xPoly, "POLYGON")
+      xPoly <- sf::st_cast(xPoly, "POLYGON", warn = FALSE)
     }
 
     # then append cutouts for spatstat.geom::owin() to the owinList

--- a/R/makeLines.R
+++ b/R/makeLines.R
@@ -13,13 +13,13 @@
 #' @param angle Orientation of the transects. \code{angle = 0} produces
 #' transects oriented North-South (the default), \code{angle = 90} produces
 #' East-West transects.
-#' @param minLengthKm Minimum length required for an individual transect line
-#' (in kilometers)
+#' @param minLengthKm Minimum length (km) required for an individual transect
+#' line to be surveyed.
 #' @param offset An offset to use when placing transects. By default the central
 #' transect is aligned with the center of the polygon.
-#' @param minSpace Optional minimal line spacing (in kilometers) to consider when
+#' @param minSpace Optional minimal line spacing (in km) to consider when
 #' optimizing transect placement (default is NULL).
-#' @param maxSpace Optional maximum line spacing (in kilometers) to consider when
+#' @param maxSpace Optional maximum line spacing (in km) to consider when
 #' optimizing transect placement (default is NULL).
 #' @param optimTol Optional tolerance value indicating the maximum allowable
 #' deviation from \code{totalLengthKm} expressed as a proportion (default is 0.01).
@@ -40,7 +40,7 @@
 #'   \item{summary}{\code{data.frame} summary of transect lines}
 #' }
 #'
-#' @author Tom Prebyl, minor contributions by Jason Carlisle
+#' @author Tom Prebyl, minor contributions by Jason Carlisle and Garrett Catlin
 #' @importFrom sf st_difference st_union st_coordinates st_sfc st_bbox st_crs st_length st_write st_linestring
 #' @import spatstat
 #' @import spatstat.geom

--- a/man/calcLineLength.Rd
+++ b/man/calcLineLength.Rd
@@ -26,7 +26,7 @@ from past surveys are likely your best option here.  Used to calculate the
 expected density of pronghorn in the survey area.}
 
 \item{p}{Scalar, expected probability of detecting pronghorn in the herd
-unit.  Defaults to 0.58, the average p from past surveys in Wyoming.}
+unit.  Defaults to 0.58, the average p from surveys conducted before 2022.}
 
 \item{w}{Scalar, width (m) of the survey strip.  Defaults to 200 m, the
 standard width using the Wyoming survey protocol.}
@@ -36,8 +36,8 @@ pronghorn groups, which is a bit subjective, but should provide plenty of
 detections to fit a robust detection model.}
 
 \item{avgGroupSize}{Scalar, expected average number of pronghorn in each
-group detected.  Defaults to 2.3, the average group size from past surveys
-in Wyoming.}
+group detected.  Defaults to 2.3, the average group size from surveys
+conducted before 2022.}
 }
 \value{
 Scalar, the total length (km) of transects to survey.

--- a/man/makeLines.Rd
+++ b/man/makeLines.Rd
@@ -32,16 +32,16 @@ exclusion area where line transects will not be generated.}
 transects oriented North-South (the default), \code{angle = 90} produces
 East-West transects.}
 
-\item{minLengthKm}{Minimum length required for an individual transect line
-(in kilometers)}
+\item{minLengthKm}{Minimum length (km) required for an individual transect
+line to be surveyed.}
 
 \item{offset}{An offset to use when placing transects. By default the central
 transect is aligned with the center of the polygon.}
 
-\item{minSpace}{Optional minimal line spacing (in kilometers) to consider when
+\item{minSpace}{Optional minimal line spacing (in km) to consider when
 optimizing transect placement (default is NULL).}
 
-\item{maxSpace}{Optional maximum line spacing (in kilometers) to consider when
+\item{maxSpace}{Optional maximum line spacing (in km) to consider when
 optimizing transect placement (default is NULL).}
 
 \item{optimTol}{Optional tolerance value indicating the maximum allowable
@@ -94,5 +94,5 @@ plot(testLines$lines['lineID'], add = T, col = 'red')
 }
 }
 \author{
-Tom Prebyl, minor contributions by Jason Carlisle
+Tom Prebyl, minor contributions by Jason Carlisle and Garrett Catlin
 }


### PR DESCRIPTION
Adds changes proposed in #5.

In `makeLines`:

- loops through `xPoly` (if applicable) to create new list to pass to `spatstat.geom::owin()` which fixes errors in some fringe-case calculations
- removes diffPoly creation since it was only passed to the owin() call

In `calcLineLength`:

- adds a simple `sf::st_union()` for the occupiedPolygon to handle multiple polygons being passed